### PR TITLE
Test hash argument with Ruby 3

### DIFF
--- a/test/memoist_test.rb
+++ b/test/memoist_test.rb
@@ -97,6 +97,16 @@ class MemoistTest < Minitest::Test
       @counter.count(:do_with_special)
     end
 
+    def format_metadata(metadata)
+      @counter.call(:format_metadata)
+      "#{metadata[:grade]}: #{metadata[:comment]}"
+    end
+    memoize :format_metadata
+
+    def format_metadata_calls
+      @counter.count(:format_metadata)
+    end
+
     protected
 
     def memoize_protected_test
@@ -292,6 +302,18 @@ class MemoistTest < Minitest::Test
     assert_equal 4, @person.do_with_special_calls
   end
 
+  def test_memoize_with_hash_for_ruby3
+    metadata = { grade: 42, comment: 'The meaning.' }
+    assert_equal '42: The meaning.', @person.format_metadata(metadata)
+    assert_equal 1, @person.format_metadata_calls
+
+    assert_equal '42: The meaning.', @person.format_metadata(metadata)
+    assert_equal 1, @person.format_metadata_calls
+
+    assert_equal '44: The name.', @person.format_metadata({ grade: 44, comment: 'The name.'})
+    assert_equal 2, @person.format_metadata_calls
+  end
+
   def test_memoization_with_punctuation
     assert_equal true, @person.name?
 
@@ -375,7 +397,7 @@ class MemoistTest < Minitest::Test
     # Student < Person   memoize :name, :identifier => :student
     # Teacher < Person   memoize :seniority
 
-    expected = %w[age do_with_special is_developer? memoize_protected_test name name? sleep update update_attributes]
+    expected = %w[age do_with_special format_metadata is_developer? memoize_protected_test name name? sleep update update_attributes]
     structs = Person.all_memoized_structs
     assert_equal expected, structs.collect(&:memoized_method).collect(&:to_s).sort
     assert_equal '@_memoized_name', structs.detect { |s| s.memoized_method == :name }.ivar


### PR DESCRIPTION
Test what happens if we pass a hash to the memoized method.

When we pass a hash as the only argument to the memoized method, we see a warning:
```
warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

The goal of this PR is to test this case on Ruby 3.

It works correctly on Ruby 3  even though there is the warning in Ruby 2.7.5:
```
➭ rvm use ruby-2.7.5
Using .rvm/gems/ruby-2.7.5
➭ RUBY_OPT=-w rake test
Run options: --seed 63882

# Running:

.........................memoist/test/memoist_test.rb:307: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
memoist/lib/memoist.rb:207: warning: The called method `format_metadata' is defined here
memoist/test/memoist_test.rb:310: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
memoist/lib/memoist.rb:207: warning: The called method `format_metadata' is defined here
memoist/test/memoist_test.rb:313: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
memoist/lib/memoist.rb:207: warning: The called method `format_metadata' is defined here
........

Finished in 0.002699s, 12228.6671 runs/s, 59661.0730 assertions/s.
33 runs, 161 assertions, 0 failures, 0 errors, 0 skips
➭ rvm use ruby-3.0.3
Using .rvm/gems/ruby-3.0.3
➭ RUBY_OPT=-w rake test
Run options: --seed 35080

# Running:

.................................

Finished in 0.005073s, 6504.8971 runs/s, 31736.0132 assertions/s.
33 runs, 161 assertions, 0 failures, 0 errors, 0 skips

```
